### PR TITLE
Add rustls TLS backend feature flags

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,12 +22,18 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
         components: clippy, rustfmt
-    - name: build crates and examples
+    - name: build crates and examples (native-tls)
       run: |
-        cargo build --workspace --all-targets --all-features
-    - name: run clippy
+        cargo build --workspace --all-targets --features native-tls
+    - name: build crates and examples (rustls-tls)
       run: |
-        cargo clippy --workspace --all-targets --all-features -- --deny clippy::all
+        cargo build --workspace --all-targets --no-default-features --features rustls-tls-webpki-roots
+    - name: run clippy (native-tls)
+      run: |
+        cargo clippy --workspace --all-targets --features native-tls -- --deny clippy::all
+    - name: run clippy (rustls-tls)
+      run: |
+        cargo clippy --workspace --all-targets --no-default-features --features rustls-tls-webpki-roots -- --deny clippy::all
     - name: install nextest
       uses: taiki-e/install-action@nextest
     - name: run unit tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,15 @@ indexmap = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strip-ansi-escapes = "0.2.1"
-tanu-core = { version = ">=0.17.0", features = ["grpc", "json"] }
+tanu-core = { version = ">=0.20.1", default-features = false, features = ["grpc", "json"] }
 uuid = { version = "1.17.0", features = ["v4", "serde"] }
 url = { version = "2", features = ["serde"] }
 sha2 = "0.10"
 hostname = "0.4"
+
+[features]
+default = ["native-tls"]
+native-tls = ["tanu-core/native-tls"]
+rustls-tls = ["tanu-core/rustls-tls"]
+rustls-tls-webpki-roots = ["tanu-core/rustls-tls-webpki-roots"]
+rustls-tls-native-roots = ["tanu-core/rustls-tls-native-roots"]

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -4,6 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tanu-allure = { path = ".." }
-tanu = { version = ">=0.17.0", features = ["grpc", "json"] }
+tanu-allure = { path = "..", default-features = false }
+tanu = { version = ">=0.20.1", default-features = false, features = ["grpc", "json"] }
 tokio = { version = "1", features = ["full"] }
+
+[features]
+default = ["native-tls"]
+native-tls = ["tanu/native-tls", "tanu-allure/native-tls"]
+rustls-tls-webpki-roots = ["tanu/rustls-tls-webpki-roots", "tanu-allure/rustls-tls-webpki-roots"]
+rustls-tls-native-roots = ["tanu/rustls-tls-native-roots", "tanu-allure/rustls-tls-native-roots"]


### PR DESCRIPTION
Adds TLS passthrough features to support rustls as an alternative to native-tls, matching tanu-core v0.20.1+ feature flag structure.